### PR TITLE
Correction of a1839745.txt Change Log

### DIFF
--- a/docs/a1839745.txt
+++ b/docs/a1839745.txt
@@ -6,6 +6,10 @@
 
 ## [0.1.1] - 2024-09-23
 
+### Added
+
+- Initial commit
+
 ### Changed
 - Removed the 3 insteritons of 'XXXXXXX' from line 1
 


### PR DESCRIPTION
In the previous update, the log of adding the initial commit was removed. This mistake has been reversed